### PR TITLE
Add checking around possible empty fields generating empty queries

### DIFF
--- a/app/services/data/copy-claim-data-to-internal.js
+++ b/app/services/data/copy-claim-data-to-internal.js
@@ -20,10 +20,18 @@ function copyEligibilityDataIfPresent (data, trx) {
         return trx('IntSchema.Prisoner').insert(data.Prisoner)
       })
       .then(function () {
-        return trx('IntSchema.EligibleChild').insert(data.EligibleChild)
+        if (data.EligibleChild.length > 0) {
+          return trx('IntSchema.EligibleChild').insert(data.EligibleChild)
+        } else {
+          return Promise.resolve()
+        }
       })
       .then(function () {
-        return trx('IntSchema.Benefit').insert(data.Benefit)
+        if (data.Benefit) {
+          return trx('IntSchema.Benefit').insert(data.Benefit)
+        } else {
+          return Promise.resolve()
+        }
       })
   } else {
     return Promise.resolve()
@@ -50,16 +58,32 @@ function copyClaimData (data, additionalData, trx) {
       data.ClaimExpenses.forEach(function (claimExpense) {
         claimExpense.Cost = parseFloat(claimExpense.Cost).toFixed(2)
       })
-      return trx('IntSchema.ClaimExpense').insert(data.ClaimExpenses)
+      if (data.ClaimExpenses.length > 0) {
+        return trx('IntSchema.ClaimExpense').insert(data.ClaimExpenses)
+      } else {
+        return Promise.resolve()
+      }
     })
     .then(function () {
-      return trx('IntSchema.ClaimChild').insert(data.ClaimChildren)
+      if (data.ClaimChildren.length > 0) {
+        return trx('IntSchema.ClaimChild').insert(data.ClaimChildren)
+      } else {
+        return Promise.resolve()
+      }
     })
     .then(function () {
-      return trx('IntSchema.ClaimDocument').insert(data.ClaimDocument)
+      if (data.ClaimDocument.length > 0) {
+        return trx('IntSchema.ClaimDocument').insert(data.ClaimDocument)
+      } else {
+        return Promise.resolve()
+      }
     })
     .then(function () {
-      return trx('IntSchema.ClaimEscort').insert(data.ClaimEscort)
+      if (data.ClaimEscort.length > 0) {
+        return trx('IntSchema.ClaimEscort').insert(data.ClaimEscort)
+      } else {
+        return Promise.resolve()
+      }
     })
     .then(function () {
       return insertClaimEvent(data.Claim.Reference, data.Claim.EligibilityId, data.Claim.ClaimId, null, claimEventEnum.CLAIM_SUBMITTED.value, additionalData, null, true, trx)


### PR DESCRIPTION
In 0.95.* of knex, empty data causes errors in the queries so more checking is needed to allow tasks to run correctly.