### PR TITLE
Ignore security warning 1002419

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,5 +1,6 @@
 {
     "low": true,
     "package-manager": "auto",
-    "registry": "https://registry.npmjs.org"
+    "registry": "https://registry.npmjs.org",
+    "allowlist": [1002419]
 }


### PR DESCRIPTION
Only affects Windows - same issue ignored in `.trivyignore`.