### PR TITLE
Remove ttlSecondsAfterFinished for live migration

### DIFF
--- a/helm_deploy/help-with-prison-visits-asynchronous-worker/templates/daily-tasks-cron.yaml
+++ b/helm_deploy/help-with-prison-visits-asynchronous-worker/templates/daily-tasks-cron.yaml
@@ -12,7 +12,6 @@ spec:
   successfulJobsHistoryLimit: 5
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 86400
       template:
         spec:
           containers:

--- a/helm_deploy/help-with-prison-visits-asynchronous-worker/templates/payment-run-cron.yaml
+++ b/helm_deploy/help-with-prison-visits-asynchronous-worker/templates/payment-run-cron.yaml
@@ -12,7 +12,6 @@ spec:
   successfulJobsHistoryLimit: 5
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 86400
       template:
         spec:
           containers:

--- a/helm_deploy/help-with-prison-visits-asynchronous-worker/templates/worker-tasks-cron.yaml
+++ b/helm_deploy/help-with-prison-visits-asynchronous-worker/templates/worker-tasks-cron.yaml
@@ -12,7 +12,6 @@ spec:
   successfulJobsHistoryLimit: 15
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 86400
       template:
         spec:
           containers:


### PR DESCRIPTION
As per https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/migrate-to-live-k8s-jobs.html#kubernetes-cronjobs-and-tzcronjobs