### PR TITLE
VB-1190: Flush Application Insights data before exit

### DIFF
--- a/app/services/workers/auto-approve-claims.js
+++ b/app/services/workers/auto-approve-claims.js
@@ -10,7 +10,9 @@ const autoApproveClaims = function () {
   return getAutoApproveClaims()
     .then(function (data) {
       claimData = data
+      log.info(`Auto approval: ${claimData.length} claims found`)
       claimData.forEach(function (claim) {
+        log.info(`Auto approval: processing ClaimId ${claim.ClaimId}`)
         return autoApproveClaim(claim.Reference, claim.EligibilityId, claim.ClaimId, claim.EmailAddress)
           .then(function () {
             return deleteAutoApproveClaim(claim.AutoApprovalId)

--- a/start-daily-auto-approval-check.js
+++ b/start-daily-auto-approval-check.js
@@ -1,5 +1,5 @@
 require('dotenv').config()
-require('./app/azure-appinsights')
+const appInsights = require('./app/azure-appinsights')
 const log = require('./app/services/log')
 const { autoApproveClaims } = require('./app/services/workers/auto-approve-claims')
 
@@ -8,9 +8,16 @@ log.info('Starting auto approval checks')
 autoApproveClaims()
   .then(function () {
     log.info('Auto approval checks completed')
-    process.exit()
+    if (appInsights) {
+      appInsights.flush({ callback: () => process.exit() })
+    }
   })
   .catch(function (error) {
     log.error('Failed auto approval checks', error)
+    if (appInsights) {
+      appInsights.flush({ callback: () => process.exit(1) })
+    }
+  })
+  .finally(() => {
     process.exit()
   })

--- a/start-daily-tasks.js
+++ b/start-daily-tasks.js
@@ -1,5 +1,5 @@
 require('dotenv').config()
-require('./app/azure-appinsights')
+const appInsights = require('./app/azure-appinsights')
 const log = require('./app/services/log')
 const { sendAllAdvanceClaimRemindersForDay } = require('./app/services/workers/send-all-advance-claim-reminders-for-day')
 const { sendRequestInformationRemindersForDay } = require('./app/services/workers/send-request-information-reminders-for-day')
@@ -16,9 +16,16 @@ Promise.all([
   autoRejectClaims()])
   .then(function () {
     log.info('Daily tasks completed')
-    process.exit()
+    if (appInsights) {
+      appInsights.flush({ callback: () => process.exit() })
+    }
   })
   .catch(function (error) {
     log.error('Failed daily tasks run', error)
+    if (appInsights) {
+      appInsights.flush({ callback: () => process.exit(1) })
+    }
+  })
+  .finally(() => {
     process.exit()
   })

--- a/start-worker-tasks.js
+++ b/start-worker-tasks.js
@@ -1,11 +1,23 @@
 require('dotenv').config()
-require('./app/azure-appinsights')
+const appInsights = require('./app/azure-appinsights')
 const log = require('./app/services/log')
 const processTasks = require('./app/process-tasks')
 
 log.info('Started worker')
 
-processTasks().then(function () {
-  log.info('Worker completed processing tasks')
-  process.exit()
-})
+processTasks()
+  .then(function () {
+    log.info('Worker completed processing tasks')
+    if (appInsights) {
+      appInsights.flush({ callback: () => process.exit() })
+    }
+  })
+  .catch(function (error) {
+    log.error('Failed processing tasks', error)
+    if (appInsights) {
+      appInsights.flush({ callback: () => process.exit(1) })
+    }
+  })
+  .finally(() => {
+    process.exit()
+  })


### PR DESCRIPTION
Data is regularly not getting sent to Application Insights from cron jobs because the process exits before this can happen. See [docs](https://learn.microsoft.com/en-us/azure/azure-monitor/app/nodejs#flush):

> By default, telemetry is buffered for 15 seconds before it's sent to the ingestion server. If your application has a short lifespan, such as a CLI tool, it might be necessary to manually flush your buffered telemetry when the application terminates by using appInsights.defaultClient.flush().

This change exits the process once the data is flushed. It also handles `appInsights` not being present - e.g. in a local dev environment.
